### PR TITLE
Simplify remoteExtPath regex

### DIFF
--- a/src/Deserializers/resources.php
+++ b/src/Deserializers/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(

--- a/src/Serializers/resources.php
+++ b/src/Serializers/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(

--- a/src/resources.php
+++ b/src/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(

--- a/tests/Deserializers/resources.php
+++ b/tests/Deserializers/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(

--- a/tests/Serializers/resources.php
+++ b/tests/Serializers/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(

--- a/tests/resources.php
+++ b/tests/resources.php
@@ -7,17 +7,12 @@
  */
 return call_user_func( function() {
 
-	preg_match(
-		'+^(.*?)' . preg_quote( DIRECTORY_SEPARATOR ) . '(vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '(.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '../' . $remoteExtPathParts[2]
-			. DIRECTORY_SEPARATOR . $remoteExtPathParts[3],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	$modules = array(


### PR DESCRIPTION
The complexity of this regular expression is just not needed. Just search for the first occurrence of `/vendor/` or `/extensions/` and match everything from there, that's it. Using a regex character (`+`) as delimiter does have the advantage that it must not be repeated when calling `preg_quote`, it's always quoted.