### PR TITLE
Fix UnUnserializableValue rename

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wikibase/serialization-javascript",
 	"description": "Wikibase datamodel serialization implementation in JavaScript",
 	"require": {
-		"data-values/javascript": "~0.6.0",
+		"data-values/javascript": "~0.7.0",
 		"wikibase/data-model-javascript": "~1.0.0"
 	},
 	"license": "GPL-2.0+",

--- a/src/Deserializers/SnakDeserializer.js
+++ b/src/Deserializers/SnakDeserializer.js
@@ -35,7 +35,7 @@ MODULE.SnakDeserializer = util.inherit( 'WbSnakDeserializer', PARENT, {
 			try {
 				dataValue = dv.newDataValue( type, value );
 			} catch( error ) {
-				dataValue = new dv.UnUnserializableValue( value, type, error );
+				dataValue = new dv.UnDeserializableValue( value, type, error );
 			}
 
 			return new wb.datamodel.PropertyValueSnak( serialization.property, dataValue );


### PR DESCRIPTION
Caused by https://github.com/wmde/DataValuesJavascript/pull/58.