### PR TITLE
Add function names to JavaScript closures

### DIFF
--- a/src/DeserializerFactory.js
+++ b/src/DeserializerFactory.js
@@ -12,7 +12,7 @@ var MODULE = wb.serialization;
  *
  * @constructor
  */
-var SELF = MODULE.DeserializerFactory = function wbDeserializerFactory() {
+var SELF = MODULE.DeserializerFactory = function WbSerializationDeserializerFactory() {
 	this._strategyProvider = new MODULE.StrategyProvider();
 
 	this.registerDeserializer( MODULE.ClaimDeserializer, wb.datamodel.Claim );

--- a/src/Deserializers/Deserializer.js
+++ b/src/Deserializers/Deserializer.js
@@ -13,7 +13,7 @@
 	 *
 	 * @constructor
 	 */
-	var SELF = MODULE.Deserializer = function WbDeserializer() {};
+	var SELF = MODULE.Deserializer = function WbSerializationDeserializer() {};
 
 	$.extend( SELF.prototype, {
 		/**

--- a/src/SerializerFactory.js
+++ b/src/SerializerFactory.js
@@ -12,7 +12,7 @@ var MODULE = wb.serialization;
  *
  * @constructor
  */
-var SELF = MODULE.SerializerFactory = function WbSerializerProvider() {
+var SELF = MODULE.SerializerFactory = function WbSerializationSerializerFactory() {
 	this._strategyProvider = new MODULE.StrategyProvider();
 
 	this.registerSerializer( MODULE.ClaimGroupSerializer, wb.datamodel.ClaimGroup );

--- a/src/Serializers/Serializer.js
+++ b/src/Serializers/Serializer.js
@@ -13,7 +13,7 @@
 	 *
 	 * @constructor
 	 */
-	var SELF = MODULE.Serializer = function WbSerializer() {};
+	var SELF = MODULE.Serializer = function WbSerializationSerializer() {};
 
 	$.extend( SELF.prototype, {
 		/**


### PR DESCRIPTION
These function names are not meant to be used, they make debugging easier because the debugger can then show the function name.