### PR TITLE
Update to data-values/javascript 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ version 2.0 of this package:
 
 ## Release notes
 
+### 2.0.3 (2015-05-15)
+
+* Updated to data-values/javascript 0.7.0.
+
 ### 2.0.2 (2014-12-17)
 
 #### Bugfixes

--- a/init.php
+++ b/init.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.2' );
+define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.3' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {


### PR DESCRIPTION
All other changes since 2.0.2 seem to be purely internal, see https://github.com/wmde/WikibaseSerializationJavaScript/compare/2.0.2...master.

[Bug: T99231](https://phabricator.wikimedia.org/T99231)