### PR TITLE
Remove MEDIAWIKI dependency check

### DIFF
--- a/resources.php
+++ b/resources.php
@@ -1,12 +1,11 @@
 <?php
+
 /**
+ * @licence GNU GPL v2+
+ * @author H. Snater < mediawiki@snater.com >
+ *
  * @codeCoverageIgnoreStart
  */
-
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'Not an entry point.' );
-}
-
 return call_user_func( function() {
 	global $wgResourceModules;
 

--- a/resources.tests.php
+++ b/resources.tests.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
+ * @licence GNU GPL v2+
+ * @author H. Snater < mediawiki@snater.com >
+ *
  * @codeCoverageIgnoreStart
  */
-
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'Not an entry point.' );
-}
-
-$GLOBALS['wgHooks']['ResourceLoaderTestModules'][] = function(
+global $wgHooks;
+$wgHooks['ResourceLoaderTestModules'][] = function(
 	array &$testModules,
 	\ResourceLoader &$resourceLoader
 ) {

--- a/src/Deserializers/resources.php
+++ b/src/Deserializers/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >

--- a/src/Serializers/resources.php
+++ b/src/Serializers/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >

--- a/src/resources.php
+++ b/src/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >

--- a/tests/Deserializers/resources.php
+++ b/tests/Deserializers/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >

--- a/tests/Serializers/resources.php
+++ b/tests/Serializers/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >

--- a/tests/resources.php
+++ b/tests/resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >


### PR DESCRIPTION
I checked and no other set of resources files do this "not an entry point" check. This makes the files more similar to https://github.com/wikimedia/mediawiki-extensions-WikibaseJavaScriptApi/blob/master/resources.php and https://github.com/wikimedia/mediawiki-extensions-WikibaseJavaScriptApi/blob/master/resources.test.php.