### PR TITLE
Declare compatibility with DataModel JavaScript 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ version 2.0 of this package:
 
 ## Release notes
 
+### 2.0.4 (2016-01-18)
+
+* Added compatibility with DataModel JavaScript 2.0.0.
+
 ### 2.0.3 (2015-06-03)
 
 * Updated to DataValues JavaScript 0.7.0.
@@ -36,7 +40,7 @@ version 2.0 of this package:
 ### 2.0.1 (2014-11-05)
 * Fixed the required DataModel JavaScript version.
 
-### 2.0 (2014-11-05)
+### 2.0.0 (2014-11-05)
 
 * Removed <code>wikibase.serialization.entities</code> ResourceLoader module; use <code>wikibase.serialization.EntityDeserializer</code> instead.
 * Removed options from Serializer/Deserializer as it was never used and there is no intention to use options.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Wikibase datamodel serialization implementation in JavaScript",
 	"require": {
 		"data-values/javascript": "~0.7.0",
-		"wikibase/data-model-javascript": "~1.0.0"
+		"wikibase/data-model-javascript": "~2.0.0|~1.0.0"
 	},
 	"license": "GPL-2.0+",
 	"authors": [

--- a/init.php
+++ b/init.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.3' );
+define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.4' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {


### PR DESCRIPTION
I double checked every detail in https://github.com/wmde/WikibaseDataModelJavascript and could not find a reason why this component should not be compatible with both versions.

This update is required to be able to update Wikibase.git to the new version of DataModel JavaScript.