### PR TITLE
Revert downgrade to JSHint 2.8

### DIFF
--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -3,7 +3,7 @@
 set -x
 
 if [[ $RUNJOB == jshint ]]; then
-	npm install jshint@~2.8
+	npm install jshint
 	jshint src/ tests/
 	exit $?
 fi

--- a/src/Deserializers/SnakListDeserializer.js
+++ b/src/Deserializers/SnakListDeserializer.js
@@ -5,6 +5,21 @@ var MODULE = wb.serialization,
 	PARENT = MODULE.Deserializer;
 
 /**
+ * @param {Object[]} serializedSnaks
+ * @param {wikibase.datamodel.SnakList} snakList
+ * @return {wikibase.datamodel.SnakList}
+ */
+function addSerializedSnaksToSnakList( serializedSnaks, snakList ) {
+	var snakDeserializer = new MODULE.SnakDeserializer();
+
+	for( var i = 0; i < serializedSnaks.length; i++ ) {
+		snakList.addItem( snakDeserializer.deserialize( serializedSnaks[i] ) );
+	}
+
+	return snakList;
+}
+
+/**
  * @class wikibase.serialization.SnakListDeserializer
  * @extends wikibase.serialization.Deserializer
  * @since 2.0
@@ -62,20 +77,5 @@ MODULE.SnakListDeserializer = util.inherit( 'WbSnakListDeserializer', PARENT, {
 		return snakList;
 	}
 } );
-
-/**
- * @param {Object[]} serializedSnaks
- * @param {wikibase.datamodel.SnakList} snakList
- * @return {wikibase.datamodel.SnakList}
- */
-function addSerializedSnaksToSnakList( serializedSnaks, snakList ) {
-	var snakDeserializer = new MODULE.SnakDeserializer();
-
-	for( var i = 0; i < serializedSnaks.length; i++ ) {
-		snakList.addItem( snakDeserializer.deserialize( serializedSnaks[i] ) );
-	}
-
-	return snakList;
-}
 
 }( wikibase, util, jQuery ) );


### PR DESCRIPTION
I want to see the number of warnings the bogus JSHint 2.9 creates in the report. We already fixed these warnings in most repositories. It may be worth the trouble to also update this repository, for consistency.

This reverts #25.