### PR TITLE
Release 2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ version 2.0 of this package:
 
 ## Release notes
 
+### 2.0.6 (2016-01-27)
+
+* Added compatibility with DataValues JavaScript 0.8.0.
+
 ### 2.0.5 (2016-01-27)
 
 * Tests are now compatible with QUnit's requireExpects enabled.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wikibase/serialization-javascript",
 	"description": "Wikibase datamodel serialization implementation in JavaScript",
 	"require": {
-		"data-values/javascript": "~0.7.0",
+		"data-values/javascript": "~0.8.0|~0.7.0",
 		"wikibase/data-model-javascript": "~2.0.0|~1.0.0"
 	},
 	"license": "GPL-2.0+",

--- a/init.php
+++ b/init.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.5' );
+define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.6' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {


### PR DESCRIPTION
None of the changes in https://github.com/wmde/DataValuesJavascript/compare/0.7.0...0.8.0 is used in this component. So it's compatible with both versions.

This is needed for https://gerrit.wikimedia.org/r/263353.

[Bug: T117886](https://phabricator.wikimedia.org/T117886)