### PR TITLE
Declare compatibility with DataModel JavaScript 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ version 2.0 of this package:
 
 ## Release notes
 
+### 2.0.7 (2016-08-01)
+
+* Added compatibility with DataModel JavaScript 3.0.0.
+
 ### 2.0.6 (2016-01-27)
 
 * Added compatibility with DataValues JavaScript 0.8.0.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Wikibase datamodel serialization implementation in JavaScript",
 	"require": {
 		"data-values/javascript": "~0.8.0|~0.7.0",
-		"wikibase/data-model-javascript": "~2.0.0|~1.0.0"
+		"wikibase/data-model-javascript": "~3.0.0|~2.0.0|~1.0.0"
 	},
 	"license": "GPL-2.0+",
 	"authors": [

--- a/init.php
+++ b/init.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.6' );
+define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.7' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {


### PR DESCRIPTION
3.0.0 is not released yet, but I think this can be merged before this happens.