### PR TITLE
Add PHPCS rule set and checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+composer.lock
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
 	"name": "wikibase/serialization-javascript",
 	"description": "Wikibase datamodel serialization implementation in JavaScript",
-	"require": {
-		"data-values/javascript": "~0.8.0|~0.7.0",
-		"wikibase/data-model-javascript": "~3.0.0|~2.0.0|~1.0.0"
-	},
 	"license": "GPL-2.0+",
 	"authors": [
 		{
@@ -20,9 +16,21 @@
 		"issues": "https://phabricator.wikimedia.org/",
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
+	"require": {
+		"data-values/javascript": "~0.8.0|~0.7.0",
+		"wikibase/data-model-javascript": "~3.0.0|~2.0.0|~1.0.0"
+	},
+	"require-dev": {
+		"wikibase/wikibase-codesniffer": "^0.1.0"
+	},
 	"autoload": {
 		"files" : [
 			"init.php"
+		]
+	},
+	"scripts": {
+		"test": [
+			"vendor/bin/phpcs . -p -s"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="SerializationJavaScript">
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="108" />
+		</properties>
+	</rule>
+</ruleset>

--- a/resources.php
+++ b/resources.php
@@ -11,6 +11,6 @@ return call_user_func( function() {
 
 	$wgResourceModules = array_merge(
 		$wgResourceModules,
-		include( __DIR__ . '/src/resources.php' )
+		include __DIR__ . '/src/resources.php'
 	);
 } );

--- a/resources.tests.php
+++ b/resources.tests.php
@@ -3,19 +3,15 @@
 /**
  * @license GPL-2.0+
  * @author H. Snater < mediawiki@snater.com >
- *
- * @codeCoverageIgnoreStart
  */
 global $wgHooks;
+
 $wgHooks['ResourceLoaderTestModules'][] = function(
 	array &$testModules,
-	\ResourceLoader &$resourceLoader
+	ResourceLoader &$resourceLoader
 ) {
-
 	$testModules['qunit'] = array_merge(
 		$testModules['qunit'],
-		include( __DIR__ . '/tests/resources.php' )
+		include __DIR__ . '/tests/resources.php'
 	);
-
-	return true;
 };

--- a/src/resources.php
+++ b/src/resources.php
@@ -112,7 +112,7 @@ return call_user_func( function() {
 
 	return array_merge(
 		$modules,
-		include( __DIR__ . '/Serializers/resources.php' ),
-		include( __DIR__ . '/Deserializers/resources.php' )
+		include __DIR__ . '/Serializers/resources.php',
+		include __DIR__ . '/Deserializers/resources.php'
 	);
 } );

--- a/tests/resources.php
+++ b/tests/resources.php
@@ -88,7 +88,7 @@ return call_user_func( function() {
 
 	return array_merge(
 		$modules,
-		include( __DIR__ . '/Serializers/resources.php' ),
-		include( __DIR__ . '/Deserializers/resources.php' )
+		include __DIR__ . '/Serializers/resources.php',
+		include __DIR__ . '/Deserializers/resources.php'
 	);
 } );


### PR DESCRIPTION
This adds a PHPCS check for the first time, and fixes a few details already. Note that Travis currently doesn't run this new test. We need to change the way this code repository utilizes a `script.sh` shell script. This should be done in later patches.