### PR TITLE
Use eslint instead of jshint.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+        "extends": "wikimedia",
+        "env": {
+                "browser": true,
+                "jquery": true
+	},
+	"globals": {
+		"dataValues": false,
+		"util": false,
+		"wikibase": false
+	},
+	"rules": {
+		"computed-property-spacing": "off",
+		"indent": "off",
+		"keyword-spacing": "off",
+		"new-parens": "off",
+		"no-underscore-dangle": "off",
+		"one-var": "off",
+		"operator-linebreak": "off",
+		"space-before-function-paren": "off",
+		"vars-on-top": "off"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
-/vendor/
+vendor/
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ php:
 
 sudo: false
 
-env:
-- RUNJOB=jshint
+before_script:
+  - nvm install 4
 
-script: bash ./build/travis/script.sh
+script: npm install && npm run eslint
 
 notifications:
   irc:

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-set -x
-
-if [[ $RUNJOB == jshint ]]; then
-	npm install jshint
-	jshint src/ tests/
-	exit $?
-fi

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "directories": {
+    "lib": "src",
+    "test": "tests"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-wikimedia": "0.4.0"
+  },
+  "scripts": {
+    "eslint": "eslint ."
+  }
+}

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../.eslintrc.json",
+	"env": {
+		"qunit": true
+	},
+	"rules": {
+		"array-bracket-spacing": "off",
+		"dot-notation": "off",
+		"space-unary-ops": "off"
+	}
+}


### PR DESCRIPTION
Also removes the old-style build script and uses npm to run
the linter.

I'll add a change to run qunit tests as part of the CI build (without needing to install MediaWiki) separately.