### PR TITLE
Start using extension.json and enable PHPCS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ php:
 sudo: false
 
 before_script:
+  - composer install --prefer-source
   - nvm install 4
 
-script: npm install && npm run eslint
+script:
+  - composer test
+  - npm install && npm run eslint
 
 notifications:
   irc:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ version 2.0 of this package:
 
 ## Release notes
 
+### 2.1.0 (dev)
+
+* Updated the MediaWiki entry point to use the extension.json format.
+* Added code sniffers for JavaScript as well as PHP.
+* Dropped compatibility with PHP 5.3.
+
 ### 2.0.8 (2016-09-09)
 
 * Fix an issue with MediaWiki loading (init.mw.php)

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"scripts": {
 		"fix": "phpcbf",
 		"test": [
-			"vendor/bin/phpcs . -p -s"
+			"phpcs -p -s"
 		]
 	}
 }

--- a/init.mw.php
+++ b/init.mw.php
@@ -4,17 +4,9 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
 }
 
-$GLOBALS['wgExtensionCredits']['wikibase'][] = [
-	'path' => __FILE__,
-	'name' => 'Wikibase Serialization JavaScript',
-	'version' => WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION,
-	'author' => [
-		'[http://www.snater.com H. Snater]',
-	],
-	'url' => 'https://github.com/wmde/WikibaseSerializationJavaScript',
-	'description' => 'JavaScript library containing serializers and deserializers for the Wikibase DataModel.',
-	'license-name' => 'GPL-2.0+',
-];
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'WikibaseSerializationJavaScript', __DIR__ . '/mediawiki-extension.json' );
+}
 
 include __DIR__ . '/resources.php';
 include __DIR__ . '/resources.tests.php';

--- a/init.php
+++ b/init.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.0.8' );
+define( 'WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION', '2.1.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	call_user_func( function() {

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -1,0 +1,12 @@
+{
+	"name": "Wikibase Serialization JavaScript",
+	"version": "2.1.0",
+	"author": [
+		"[http://www.snater.com H. Snater]"
+	],
+	"url": "https://github.com/wmde/WikibaseSerializationJavaScript",
+	"description": "JavaScript library containing serializers and deserializers for the Wikibase DataModel.",
+	"license-name": "GPL-2.0+",
+	"type": "wikibase",
+	"manifest_version": 1
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="SerializationJavaScript">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
+
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="108" />
 		</properties>
 	</rule>
+
+	<file>.</file>
+	<exclude-pattern>node_modules</exclude-pattern>
 </ruleset>

--- a/tests/SerializerFactory.tests.js
+++ b/tests/SerializerFactory.tests.js
@@ -46,7 +46,7 @@ QUnit.test( 'registerSerializer(), newSerializerFor()', function( assert ) {
 	);
 
 	assert.ok(
-		serializerFactory.newSerializerFor( new ( testSets[0].Constructor ) ).constructor
+		serializerFactory.newSerializerFor( new testSets[0].Constructor() ).constructor
 			=== testSets[0].Serializer,
 		'Retrieved serializer by object.'
 	);


### PR DESCRIPTION
This patch is intended to do all the following things:
* Make Travis run PHPCS.
* Start using the extension.json format. Hooks and resource loader modules are missing, but it's a start.
* I'm also preparing a release here. But it does not contain anything relevant, so I suggest to *not* tag the actual release right now. We can do this any time later.