### PR TITLE
Add support for serialization of snak hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ version 2.0 of this package:
 * Updated the MediaWiki entry point to use the extension.json format.
 * Added code sniffers for JavaScript as well as PHP.
 * Dropped compatibility with PHP 5.3.
+* Added support for deserializing snak hashes.
 
 ### 2.0.8 (2016-09-09)
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"data-values/javascript": "~0.8.0|~0.7.0",
-		"wikibase/data-model-javascript": "~3.0.0|~2.0.0|~1.0.0"
+		"wikibase/data-model-javascript": "^3.1.0"
 	},
 	"require-dev": {
 		"wikibase/wikibase-codesniffer": "^0.1.0"

--- a/src/Deserializers/SnakDeserializer.js
+++ b/src/Deserializers/SnakDeserializer.js
@@ -24,9 +24,9 @@ MODULE.SnakDeserializer = util.inherit( 'WbSnakDeserializer', PARENT, {
 	 */
 	deserialize: function( serialization ) {
 		if( serialization.snaktype === 'novalue' ) {
-			return new wb.datamodel.PropertyNoValueSnak( serialization.property );
+			return new wb.datamodel.PropertyNoValueSnak( serialization.property, serialization.hash );
 		} else if( serialization.snaktype === 'somevalue' ) {
-			return new wb.datamodel.PropertySomeValueSnak( serialization.property );
+			return new wb.datamodel.PropertySomeValueSnak( serialization.property, serialization.hash );
 		} else if( serialization.snaktype === 'value' ) {
 			var dataValue = null,
 				type = serialization.datavalue.type,
@@ -38,7 +38,7 @@ MODULE.SnakDeserializer = util.inherit( 'WbSnakDeserializer', PARENT, {
 				dataValue = new dv.UnDeserializableValue( value, type, error.message );
 			}
 
-			return new wb.datamodel.PropertyValueSnak( serialization.property, dataValue );
+			return new wb.datamodel.PropertyValueSnak( serialization.property, dataValue, serialization.hash );
 		}
 
 		throw new Error( 'Incompatible snak type' );

--- a/src/Serializers/SnakSerializer.js
+++ b/src/Serializers/SnakSerializer.js
@@ -32,6 +32,10 @@ MODULE.SnakSerializer = util.inherit( 'WbSnakSerializer', PARENT, {
 			property: snak.getPropertyId()
 		};
 
+		if( snak.getHash() !== null ) {
+			serialization.hash = snak.getHash();
+		}
+
 		if( snak instanceof wikibase.datamodel.PropertyValueSnak ) {
 			var dataValue = snak.getValue();
 


### PR DESCRIPTION
`SnakSerializer` and `SnakDeserializer` gain support for serializing / deserializing the hash of a snak. (Serializing hashes is not required when sending serializations to the API, but the Wikibase view code assumes that serialization+deserialization is a lossless roundtrip, so if we don’t serialize it, the hash is lost when setting a new snak on a snakview.)