### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ JavaScript library containing serializers and deserializers for the Wikibase Dat
 
 ## Release notes
 
-### 3.0.0 (dev)
+### 3.0.0 (2017-10-10)
 
 * Made the library a pure JavaScript library.
+* Removed MediaWiki extension registration.
 * Removed MediaWiki ResourceLoader module definitions.
 * Raised DataValues JS library version requirement to 0.10.0, and Wikibase Data Model JS library version requirement to 4.0.0.
 * Removed all serializers and deserializers for Claim collections:
@@ -16,6 +17,7 @@ JavaScript library containing serializers and deserializers for the Wikibase Dat
   * Removed ClaimGroupSetSerializer
   * Removed ClaimListDeserializer
   * Removed ClaimListSerializer
+* Removed WIKIBASE_SERIALIZATION_JAVASCRIPT_VERSION constant.
 
 ### 2.1.0 (2017-09-04)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ JavaScript library containing serializers and deserializers for the Wikibase Dat
 * Made the library a pure JavaScript library.
 * Removed MediaWiki extension registration.
 * Removed MediaWiki ResourceLoader module definitions.
-* Raised DataValues JS library version requirement to 0.10.0, and Wikibase Data Model JS library version requirement to 4.0.0.
+* Raised DataValues JavaScript library version requirement to 0.10.0.
+* Raised Wikibase DataModel JavaScript library version requirement to 4.0.0.
 * Removed all serializers and deserializers for Claim collections:
   * Removed ClaimGroupDeserializer
   * Removed ClaimGroupSerializer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wikibase-serialization",
   "description": "Wikibase datamodel serialization implementation in JavaScript",
+  "version": "3.0.0",
   "license": "GPL-2.0+",
   "contributors": [
     {


### PR DESCRIPTION
Needed for https://phabricator.wikimedia.org/T177613.

Note this includes commits from https://github.com/wmde/WikibaseSerializationJavaScript/pull/47 which should be merged first. The release-related commit is https://github.com/wmde/WikibaseSerializationJavaScript/commit/9ad2f022ede112a09154a82c1ba18c8c54015823.