### PR TITLE
Use Daniel Werners preferred email address

### DIFF
--- a/src/Deserializers/ClaimDeserializer.js
+++ b/src/Deserializers/ClaimDeserializer.js
@@ -10,7 +10,7 @@ var MODULE = wb.serialization,
  * @since 2.0
  * @license GPL-2.0+
  * @author H. Snater < mediawiki@snater.com >
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  */

--- a/src/Deserializers/Deserializer.js
+++ b/src/Deserializers/Deserializer.js
@@ -9,7 +9,7 @@
 	 * @abstract
 	 * @since 1.0
 	 * @license GPL-2.0+
-	 * @author Daniel Werner < daniel.werner@wikimedia.de >
+	 * @author Daniel Werner < daniel.a.r.werner@gmail.com >
 	 *
 	 * @constructor
 	 */

--- a/src/Deserializers/SnakDeserializer.js
+++ b/src/Deserializers/SnakDeserializer.js
@@ -10,7 +10,7 @@ var MODULE = wb.serialization,
  * @since 2.0
  * @license GPL-2.0+
  * @author H. Snater < mediawiki@snater.com >
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  */

--- a/src/Serializers/Serializer.js
+++ b/src/Serializers/Serializer.js
@@ -9,7 +9,7 @@
 	 * @abstract
 	 * @since 1.0
 	 * @license GPL-2.0+
-	 * @author Daniel Werner < daniel.werner@wikimedia.de >
+	 * @author Daniel Werner < daniel.a.r.werner@gmail.com >
 	 *
 	 * @constructor
 	 */


### PR DESCRIPTION
I contacted Daniel Werner and asked him which email address he prefers.

I had two reasons to touch this:
* Daniels wikimedia.de email does not exist any more.
* He used so many different @author tags and I wanted to unify them.