### PR TITLE
Add karma-webpack for `require` in tests/tested files

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,13 @@ module.exports = function ( config ) {
 			'tests/DeserializerFactory.tests.js'
 		],
 
+		preprocessors: {
+			'src/**/*.js': [ 'webpack' ],
+			'tests/**/*.tests.js': [ 'webpack' ]
+		},
+
+		webpack: { mode: 'development' },
+
 		port: 9876,
 
 		logLevel: config.LOG_INFO,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "karma-cli": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-qunit": "^1.2.1",
-    "qunit": "^1.0.0"
+    "karma-webpack": "^4.0.2",
+    "qunit": "^1.0.0",
+    "webpack": "^4.40.2"
   },
   "scripts": {
     "test": "npm run eslint && npm run run-tests",


### PR DESCRIPTION
MediaWiki uses the CommonJS syntax to load packageFiles* through
resource loader. Since tests in this repo are not run via the usual
resource loader + qunit runner, we can use webpack to enable support for
CommonJS module syntax.