### PR TITLE
StatementListDeserializer: do not use require/module.exports

### DIFF
--- a/src/DeserializerFactory.js
+++ b/src/DeserializerFactory.js
@@ -9,7 +9,6 @@ var MODULE = wb.serialization,
 	SiteLinkSetDeserializer = require( './Deserializers/SiteLinkSetDeserializer.js' ),
 	ReferenceListDeserializer = require( './Deserializers/ReferenceListDeserializer.js' ),
 	ReferenceDeserializer = require( './Deserializers/ReferenceDeserializer.js' ),
-	StatementListDeserializer = require( './Deserializers/StatementListDeserializer.js' ),
 	StatementGroupDeserializer = require( './Deserializers/StatementGroupDeserializer.js' ),
 	ClaimDeserializer = require( './Deserializers/ClaimDeserializer.js' ),
 	SnakListDeserializer = require( './Deserializers/SnakListDeserializer.js' );
@@ -40,7 +39,7 @@ var SELF = MODULE.DeserializerFactory = function WbSerializationDeserializerFact
 	this.registerDeserializer( MODULE.StatementDeserializer, wb.datamodel.Statement );
 	this.registerDeserializer( StatementGroupDeserializer, wb.datamodel.StatementGroup );
 	this.registerDeserializer( MODULE.StatementGroupSetDeserializer, wb.datamodel.StatementGroupSet );
-	this.registerDeserializer( StatementListDeserializer, wb.datamodel.StatementList );
+	this.registerDeserializer( MODULE.StatementListDeserializer, wb.datamodel.StatementList );
 	this.registerDeserializer( MODULE.TermDeserializer, wb.datamodel.Term );
 	this.registerDeserializer( MODULE.TermMapDeserializer, wb.datamodel.TermMap );
 };

--- a/src/Deserializers/StatementGroupDeserializer.js
+++ b/src/Deserializers/StatementGroupDeserializer.js
@@ -2,8 +2,7 @@
 	'use strict';
 
 var MODULE = wb.serialization,
-	PARENT = MODULE.Deserializer,
-	StatementListDeserializer = require( './StatementListDeserializer.js' );
+	PARENT = MODULE.Deserializer;
 
 /**
  * @class StatementGroupDeserializer
@@ -27,7 +26,7 @@ module.exports = util.inherit( 'WbStatementGroupDeserializer', PARENT, {
 			throw new Error( 'Cannot deserialize empty serialization' );
 		}
 
-		var statementListDeserializer = new StatementListDeserializer(),
+		var statementListDeserializer = new MODULE.StatementListDeserializer(),
 			statementList = statementListDeserializer.deserialize( serialization );
 
 		return new wb.datamodel.StatementGroup( statementList.getPropertyIds()[0], statementList );

--- a/src/Deserializers/StatementListDeserializer.js
+++ b/src/Deserializers/StatementListDeserializer.js
@@ -5,7 +5,7 @@ var MODULE = wb.serialization,
 	PARENT = MODULE.Deserializer;
 
 /**
- * @class StatementListDeserializer
+ * @class wikibase.serialization.StatementListDeserializer
  * @extends wikibase.serialization.Deserializer
  * @since 2.0
  * @license GPL-2.0+
@@ -13,7 +13,7 @@ var MODULE = wb.serialization,
  *
  * @constructor
  */
-module.exports = util.inherit( 'WbStatementListDeserializer', PARENT, {
+MODULE.StatementListDeserializer = util.inherit( 'WbStatementListDeserializer', PARENT, {
 	/**
 	 * @inheritdoc
 	 *

--- a/tests/Deserializers/StatementListDeserializer.tests.js
+++ b/tests/Deserializers/StatementListDeserializer.tests.js
@@ -5,8 +5,6 @@
 ( function( wb, QUnit ) {
 'use strict';
 
-var StatementListDeserializer = require( '../../src/Deserializers/StatementListDeserializer.js' );
-
 QUnit.module( 'wikibase.serialization.StatementListDeserializer' );
 
 var testSets = [
@@ -32,7 +30,7 @@ var testSets = [
 
 QUnit.test( 'deserialize()', function( assert ) {
 	assert.expect( 2 );
-	var statementListDeserializer = new StatementListDeserializer();
+	var statementListDeserializer = new wb.serialization.StatementListDeserializer();
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		assert.ok(


### PR DESCRIPTION
wikibase.serialization.StatementListDeserializer is used in
WikibaseMediaInfo.

Bug: T233705

With this PR https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/538904 is actually green.