### PR TITLE
Add StatementGroupSetDeserializer to public interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ module.exports = {
 	EntityDeserializer: wikibase.serialization.EntityDeserializer,
 	SnakDeserializer: wikibase.serialization.SnakDeserializer,
 	StatementDeserializer: wikibase.serialization.StatementDeserializer,
+	StatementGroupSetDeserializer: wikibase.serialization.StatementGroupSetDeserializer,
 	StatementListDeserializer: wikibase.serialization.StatementListDeserializer,
 	TermDeserializer: wikibase.serialization.TermDeserializer,
 	TermMapDeserializer: wikibase.serialization.TermMapDeserializer,


### PR DESCRIPTION
This was left out (mistakenly) when introducing index.js
Causing WikibaseLexeme to fail.

I double checked and nothing else is left out.