### PR TITLE
Stop hooking to globals on EntityDeserializer and TermMapSerializer

### DIFF
--- a/src/Deserializers/EntityDeserializer.js
+++ b/src/Deserializers/EntityDeserializer.js
@@ -1,15 +1,14 @@
 ( function( wb, util ) {
 	'use strict';
 
-var MODULE = wb.serialization,
-	PARENT = MODULE.Deserializer,
+var PARENT = wb.serialization.Deserializer,
 	datamodel = require( 'wikibase.datamodel' ),
 	ItemDeserializer = require( './ItemDeserializer.js' ),
 	PropertyDeserializer = require( './PropertyDeserializer.js' ),
 	StrategyProvider = require( '../StrategyProvider.js' );
 
 /**
- * @class wikibase.serialization.EntityDeserializer
+ * @class EntityDeserializer
  * @extends wikibase.serialization.Deserializer
  * @since 1.0
  * @license GPL-2.0+
@@ -17,7 +16,7 @@ var MODULE = wb.serialization,
  *
  * @constructor
  */
-MODULE.EntityDeserializer = util.inherit( 'WbEntityDeserializer', PARENT, function() {
+module.exports = util.inherit( 'WbEntityDeserializer', PARENT, function() {
 	this._strategyProvider = new StrategyProvider();
 	this._strategyProvider.registerStrategy(
 		new ItemDeserializer(), datamodel.Item.TYPE
@@ -58,5 +57,4 @@ MODULE.EntityDeserializer = util.inherit( 'WbEntityDeserializer', PARENT, functi
 	}
 } );
 
-module.exports = MODULE.EntityDeserializer;
 }( wikibase, util ) );

--- a/src/Serializers/TermMapSerializer.js
+++ b/src/Serializers/TermMapSerializer.js
@@ -2,12 +2,11 @@
 	'use strict';
 	var TermSerializer = require( './TermSerializer.js' );
 
-var MODULE = wb.serialization,
-	PARENT = MODULE.Serializer,
+var PARENT = wb.serialization.Serializer,
 	datamodel = require( 'wikibase.datamodel' );
 
 /**
- * @class wikibase.serialization.TermMapSerializer
+ * @class TermMapSerializer
  * @extends wikibase.serialization.Serializer
  * @since 2.0
  * @license GPL-2.0+
@@ -15,7 +14,7 @@ var MODULE = wb.serialization,
  *
  * @constructor
  */
-MODULE.TermMapSerializer = util.inherit( 'WbTermMapSerializer', PARENT, {
+module.exports = util.inherit( 'WbTermMapSerializer', PARENT, {
 	/**
 	 * @inheritdoc
 	 *
@@ -43,5 +42,4 @@ MODULE.TermMapSerializer = util.inherit( 'WbTermMapSerializer', PARENT, {
 	}
 } );
 
-module.exports = MODULE.TermMapSerializer;
 }( wikibase, util ) );

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 module.exports = {
 	Deserializer: wikibase.serialization.Deserializer,
-	EntityDeserializer: require( 'Deserializers/EntityDeserializer.js' ),
+	EntityDeserializer: require( './Deserializers/EntityDeserializer.js' ),
 	SnakDeserializer: wikibase.serialization.SnakDeserializer,
 	StatementDeserializer: wikibase.serialization.StatementDeserializer,
 	StatementGroupSetDeserializer: wikibase.serialization.StatementGroupSetDeserializer,
@@ -15,5 +15,5 @@ module.exports = {
 	SnakSerializer: wikibase.serialization.SnakSerializer,
 	StatementListSerializer: wikibase.serialization.StatementListSerializer,
 	StatementSerializer: wikibase.serialization.StatementSerializer,
-	TermMapSerializer: require( 'Serializers/TermMapSerializer.js' )
+	TermMapSerializer: require( './Serializers/TermMapSerializer.js' )
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 module.exports = {
 	Deserializer: wikibase.serialization.Deserializer,
-	EntityDeserializer: wikibase.serialization.EntityDeserializer,
+	EntityDeserializer: require( 'Deserializers/EntityDeserializer.js' ),
 	SnakDeserializer: wikibase.serialization.SnakDeserializer,
 	StatementDeserializer: wikibase.serialization.StatementDeserializer,
 	StatementGroupSetDeserializer: wikibase.serialization.StatementGroupSetDeserializer,
@@ -15,5 +15,5 @@ module.exports = {
 	SnakSerializer: wikibase.serialization.SnakSerializer,
 	StatementListSerializer: wikibase.serialization.StatementListSerializer,
 	StatementSerializer: wikibase.serialization.StatementSerializer,
-	TermMapSerializer: wikibase.serialization.TermMapSerializer
+	TermMapSerializer: require( 'Serializers/TermMapSerializer.js' )
 };

--- a/tests/Deserializers/EntityDeserializer.tests.js
+++ b/tests/Deserializers/EntityDeserializer.tests.js
@@ -7,6 +7,7 @@
 
 QUnit.module( 'wikibase.serialization.EntityDeserializer' );
 var FingerprintDeserializer = require( '../../src/Deserializers/FingerprintDeserializer.js' ),
+	EntityDeserializer = require( '../../src/Deserializers/EntityDeserializer.js' ),
 	datamodel = require( 'wikibase.datamodel' );
 
 /**
@@ -111,7 +112,7 @@ var testSets = [
 
 QUnit.test( 'deserialize()', function( assert ) {
 	assert.expect( 2 );
-	var entityDeserializer = new wb.serialization.EntityDeserializer();
+	var entityDeserializer = new EntityDeserializer();
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		assert.ok(
@@ -123,7 +124,7 @@ QUnit.test( 'deserialize()', function( assert ) {
 
 QUnit.test( 'registerStrategy()', function( assert ) {
 	assert.expect( 2 );
-	var entityDeserializer = new wb.serialization.EntityDeserializer();
+	var entityDeserializer = new EntityDeserializer();
 
 	var mockEntitySerialization = $.extend( true, {
 		id: 'i am an id',

--- a/tests/Deserializers/ItemDeserializer.tests.js
+++ b/tests/Deserializers/ItemDeserializer.tests.js
@@ -7,7 +7,8 @@
 
 QUnit.module( 'wikibase.serialization.EntityDeserializer' );
 
-var datamodel = require( 'wikibase.datamodel' );
+var datamodel = require( 'wikibase.datamodel' ),
+	EntityDeserializer = require( '../../src/Deserializers/EntityDeserializer.js' );
 
 var defaults = [
 	{
@@ -70,7 +71,7 @@ var testSets = [
 
 QUnit.test( 'deserialize()', function( assert ) {
 	assert.expect( 1 );
-	var entityDeserializer = new wb.serialization.EntityDeserializer();
+	var entityDeserializer = new EntityDeserializer();
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		assert.ok(

--- a/tests/Deserializers/PropertyDeserializer.tests.js
+++ b/tests/Deserializers/PropertyDeserializer.tests.js
@@ -7,7 +7,8 @@
 
 QUnit.module( 'wikibase.serialization.EntityDeserializer' );
 
-var datamodel = require( 'wikibase.datamodel' );
+var datamodel = require( 'wikibase.datamodel' ),
+	EntityDeserializer = require( '../../src/Deserializers/EntityDeserializer.js' );
 
 var defaults = [
 	{
@@ -64,7 +65,7 @@ var testSets = [
 
 QUnit.test( 'deserialize()', function( assert ) {
 	assert.expect( 1 );
-	var entityDeserializer = new wb.serialization.EntityDeserializer();
+	var entityDeserializer = new EntityDeserializer();
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		assert.ok(

--- a/tests/Serializers/TermMapSerializer.tests.js
+++ b/tests/Serializers/TermMapSerializer.tests.js
@@ -7,7 +7,8 @@
 
 QUnit.module( 'wikibase.serialization.TermMapSerializer' );
 
-var datamodel = require( 'wikibase.datamodel' );
+var datamodel = require( 'wikibase.datamodel' ),
+	TermMapSerializer = require( '../../src/Serializers/TermMapSerializer.js' );
 
 var testSets = [
 	[
@@ -36,7 +37,7 @@ var testSets = [
 
 QUnit.test( 'serialize()', function( assert ) {
 	assert.expect( 3 );
-	var termMapSerializer = new wb.serialization.TermMapSerializer();
+	var termMapSerializer = new TermMapSerializer();
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		assert.deepEqual(


### PR DESCRIPTION
These are not being used as global object anywhere anymore

Bug: T234993