### PR TITLE
Update datamodel to the version used in wikibase

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,13 +13,6 @@ module.exports = function ( config ) {
 			'node_modules/wikibase-data-values/src/DataValue.js',
 			'node_modules/wikibase-data-values/src/values/StringValue.js',
 			'node_modules/wikibase-data-values/src/values/UnDeserializableValue.js',
-			'node_modules/wikibase-data-model/src/__namespace.js',
-			'node_modules/wikibase-data-model/src/GroupableCollection.js',
-			'node_modules/wikibase-data-model/src/Group.js',
-			'node_modules/wikibase-data-model/src/Snak.js',
-			'node_modules/wikibase-data-model/src/Set.js',
-			'node_modules/wikibase-data-model/src/List.js',
-			'node_modules/wikibase-data-model/src/*.js',
 
 			'tests/**/*.tests.js'
 		],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "jquery": "^3.2.1",
-    "wikibase-data-model": "^5.1.0",
+    "wikibase-data-model": "^6.0.0",
     "wikibase-data-values": "^0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The test runner now does not need to load any datamodel files explicitly. They're all `require`d :)