### PR TITLE
Lint package file require

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
         "extends": "wikimedia",
+        "plugins": [
+                "resource-loader"
+        ],
         "env": {
                 "browser": true,
                 "jquery": true,
@@ -10,6 +13,7 @@
 		"util": false
 	},
 	"rules": {
+		"resource-loader/valid-package-file-require": "error",
 		"computed-property-spacing": "off",
 		"indent": "off",
 		"keyword-spacing": "off",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "eslint": "^6.5.1",
     "eslint-config-wikimedia": "0.4.0",
+    "eslint-plugin-resource-loader": "wmde/eslint-plugin-resource-loader#b84d53f22794bb15b98f611b541fe4d32e153720",
     "karma": "^1.7.1",
     "karma-cli": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "wikibase-data-values": "^0.10.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^6.5.1",
     "eslint-config-wikimedia": "0.4.0",
     "karma": "^1.7.1",
     "karma-cli": "^1.0.1",

--- a/tests/Serializers/TermSerializer.tests.js
+++ b/tests/Serializers/TermSerializer.tests.js
@@ -5,7 +5,7 @@
 ( function( QUnit ) {
 'use strict';
 
-var TermSerializer = require( './../../src/Serializers/TermSerializer.js' ),
+var TermSerializer = require( '../../src/Serializers/TermSerializer.js' ),
 	datamodel = require( 'wikibase.datamodel' );
 
 QUnit.module( 'TermSerializer' );


### PR DESCRIPTION
* had to upgrade eslint to make the plugin work, >= 4.0 seems to work but I see no reason to not just upgrade to 6
* fixed an "invalid" path in a test

The test folder could also be exempt from this rule because it doesn't matter there. Thoughts?