### PR TITLE
Use eslint-plugin-mediawiki

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
         "extends": "wikimedia",
         "plugins": [
-                "resource-loader"
+                "mediawiki"
         ],
         "env": {
                 "browser": true,
@@ -13,7 +13,7 @@
 		"util": false
 	},
 	"rules": {
-		"resource-loader/valid-package-file-require": "error",
+		"mediawiki/valid-package-file-require": "error",
 		"computed-property-spacing": "off",
 		"indent": "off",
 		"keyword-spacing": "off",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "eslint": "^6.5.1",
     "eslint-config-wikimedia": "0.4.0",
-    "eslint-plugin-resource-loader": "wmde/eslint-plugin-resource-loader#b84d53f22794bb15b98f611b541fe4d32e153720",
+    "eslint-plugin-mediawiki": "^0.2.1",
     "karma": "^1.7.1",
     "karma-cli": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.4",


### PR DESCRIPTION
The `valid-package-file-require` rule got upstreamed to
eslint-plugin-mediawiki.